### PR TITLE
Fixed Markdown in Chapter 5

### DIFF
--- a/Chapter5/Chapter5_Types.ipynb
+++ b/Chapter5/Chapter5_Types.ipynb
@@ -113,11 +113,11 @@
       "\n",
       "+ Sum (+)\n",
       "+ Difference (-)\n",
-      "+ Multiplication (*)\n",
+      "+ Multiplication (&#42;)\n",
       "+ Division (/): between two integers the result is equal to the integer division. In other cases, the result is real.\n",
       "+ Integer Division (//): the result is truncated to the next lower integer, even when applied to real numbers, but in this case the result type is real too.\n",
       "+ Module (%): returns the remainder of the division.\n",
-      "+ Power (\*\*): can be used to calculate the root, through fractional exponents (eg `100 \*\* 0.5`).\n",
+      "+ Power (&#42;&#42;): can be used to calculate the root, through fractional exponents (eg `100 ** 0.5`).\n",
       "+ Positive (+)\n",
       "+ Negative (-)\n",
       "\n",
@@ -1099,3 +1099,4 @@
   }
  ]
 }
+


### PR DESCRIPTION
I wasn't able to open Chapter 5 with this link http://nbviewer.ipython.org/urls/raw.github.com/ricardoduarte/python-for-developers/master/Chapter5/Chapter5_Types.ipynb (400 Bad Request). Jupyter Notebook on my local machine also refused to open the document (invalid JSON). 

Replaced `\*\* `by HTML entities.